### PR TITLE
Fix configuration name for TLS auth

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-vault-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-vault-config.adoc
@@ -300,7 +300,7 @@ To enable `cert` authentication you need to:
 1. Use SSL, see <<vault.config.ssl>>
 2. Configure a Java `Keystore` that contains the client
 certificate and the private key
-3. Set the `spring.cloud.vault.config.authentication` to `CERT`
+3. Set the `spring.cloud.vault.authentication` to `CERT`
 
 .bootstrap.yml
 ====


### PR DESCRIPTION
Fixes an incorrect reference to the property name used to set the authentication method when connecting to Vault by removing `.config` from the property name.