### PR TITLE
Refine Vault enterprise download

### DIFF
--- a/src/test/bash/install_vault.sh
+++ b/src/test/bash/install_vault.sh
@@ -10,6 +10,7 @@ set -o errexit
 EDITION="${EDITION:-oss}"
 VAULT_OSS="${VAULT_OSS:-1.11.0}"
 VAULT_ENT="${VAULT_ENT:-1.11.0}"
+VAULT_ENT_TYPE="${VAULT_ENT_TYPE:-ent}" #ent, ent.hsm, ent.hsm.fips1403
 UNAME=$(uname -s | tr '[:upper:]' '[:lower:]')
 VERBOSE=false
 VAULT_DIRECTORY=vault
@@ -83,12 +84,12 @@ function unpack() {
     rm vault
   fi
 
-  say "Unzipping ${VAULT_FILE}..."
-  verbose " unzip ../${DOWNLOAD_DIRECTORY}/${VAULT_FILE}"
+  say "Unzipping ${VAULT_ZIP}..."
+  verbose " unzip ../${DOWNLOAD_DIRECTORY}/${VAULT_ZIP}"
   if [[ ${VERBOSE} == true ]]; then
-    unzip "../${DOWNLOAD_DIRECTORY}/${VAULT_FILE}"
+    unzip "../${DOWNLOAD_DIRECTORY}/${VAULT_ZIP}" vault
   else
-    unzip -q "../${DOWNLOAD_DIRECTORY}/${VAULT_FILE}"
+    unzip -q "../${DOWNLOAD_DIRECTORY}/${VAULT_ZIP}" vault
   fi
 
   chmod a+x vault
@@ -100,17 +101,17 @@ function unpack() {
 
 function download() {
 
-  if [[ ! -f "${DOWNLOAD_DIRECTORY}/${VAULT_FILE}" ]]; then
+  if [[ ! -f "${DOWNLOAD_DIRECTORY}/${VAULT_ZIP}" ]]; then
     cd ${DOWNLOAD_DIRECTORY}
     # install Vault
     say "Downloading Vault from ${VAULT_URL}"
 
-    verbose "wget ${VAULT_URL} -O ${VAULT_FILE}"
+    verbose "wget ${VAULT_URL} -O ${VAULT_ZIP}"
 
     if [[ ${VERBOSE} == true ]]; then
-      wget "${VAULT_URL}" -O "${VAULT_FILE}"
+      wget "${VAULT_URL}" -O "${VAULT_ZIP}"
     else
-      wget "${VAULT_URL}" -q -O "${VAULT_FILE}"
+      wget "${VAULT_URL}" -q -O "${VAULT_ZIP}"
     fi
 
     if [[ $? != 0 ]]; then
@@ -125,7 +126,6 @@ function download_oss() {
 
   VAULT_VER="${VAULT_VER:-${VAULT_OSS}}"
   VAULT_ZIP="vault_${VAULT_VER}_${UNAME}_${PLATFORM}.zip"
-  VAULT_FILE=${VAULT_ZIP}
   VAULT_URL="https://releases.hashicorp.com/vault/${VAULT_VER}/${VAULT_ZIP}"
 
   download
@@ -134,10 +134,9 @@ function download_oss() {
 
 function download_enterprise() {
 
-  VAULT_VER="${VAULT_VER:-${VAULT_ENT}}"
-  VAULT_ZIP="vault-enterprise_${VAULT_VER}%2Bent_${UNAME}_${PLATFORM}.zip"
-  VAULT_FILE="vault-enterprise_${VAULT_VER}+ent_${UNAME}_${PLATFORM}.zip"
-  VAULT_URL="http://hc-enterprise-binaries.s3.amazonaws.com/vault/ent/${VAULT_VER}/${VAULT_ZIP}"
+  VAULT_VER="${VAULT_VER:-${VAULT_ENT}+${VAULT_ENT_TYPE}}"
+  VAULT_ZIP="vault_${VAULT_VER}_${UNAME}_${PLATFORM}.zip"
+  VAULT_URL="https://releases.hashicorp.com/vault/${VAULT_VER}/${VAULT_ZIP}"
 
   download
   unpack


### PR DESCRIPTION
HashiCorp has started hosting enterprise binaries on the same page as oss downloads ([example link](https://releases.hashicorp.com/vault/1.21.1+ent/)). Due to this change the download function of your script was failing for enterprise. This PR fixes it. There are other improvements that could be made. its likely the `download_oss` and `download_enterprise` functions could be combined but i didnt want to refactor too much

Changes:
- include new `VAULT_ENT_TYPE` to specify which enterprise binary to get
- remove unnecessary `VAULT_FILE`
- add the individual `vault` file to the unzip command. the enterprise zip has many more files that are likely unnecessary for testing purposes

I tested with 

```shell
EDITION=oss
PLATFORM=arm64
```

and

```shell 
EDITION=enterprise
VAULT_ENT=1.21.1
PLATFORM=arm64
VAULT_ENT_TYPE=ent