### PR TITLE
Upgrade to Vault 1.21.1

### DIFF
--- a/src/test/bash/install_vault.sh
+++ b/src/test/bash/install_vault.sh
@@ -8,8 +8,8 @@
 set -o errexit
 
 EDITION="${EDITION:-oss}"
-VAULT_OSS="${VAULT_OSS:-1.11.0}"
-VAULT_ENT="${VAULT_ENT:-1.11.0}"
+VAULT_OSS="${VAULT_OSS:-1.21.1}"
+VAULT_ENT="${VAULT_ENT:-1.21.1}"
 VAULT_ENT_TYPE="${VAULT_ENT_TYPE:-ent}" #ent, ent.hsm, ent.hsm.fips1403
 UNAME=$(uname -s | tr '[:upper:]' '[:lower:]')
 VERBOSE=false

--- a/src/test/bash/vault.conf
+++ b/src/test/bash/vault.conf
@@ -1,4 +1,6 @@
-backend "inmem" {
+storage "raft" {
+  path = "./work"
+  node_id = "mac-local"
 }
 
 listener "tcp" {
@@ -9,4 +11,5 @@ listener "tcp" {
 
 plugin_directory = "plugins"
 api_addr = "https://127.0.0.1:8200"
+cluster_addr = "http://127.0.0.1:8201"
 disable_mlock = true


### PR DESCRIPTION
Changes will appear duplicate from https://github.com/spring-cloud/spring-cloud-vault/pull/907 because this PR relies upon that one being merged then rebasing this PR

Vault no longer supports `inmem`. To make upgrading possible I added a new raft block to the config which stores the vault db in the `work/` dir. I can move this anywhere or add any cleanup if required.