### PR TITLE
fix linting issue on aws files

### DIFF
--- a/spring-cloud-vault-config-aws/src/test/java/org/springframework/cloud/vault/config/aws/AwsSecretIntegrationTests.java
+++ b/spring-cloud-vault-config-aws/src/test/java/org/springframework/cloud/vault/config/aws/AwsSecretIntegrationTests.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.vault.config.VaultConfigOperations;

--- a/spring-cloud-vault-config-aws/src/test/java/org/springframework/cloud/vault/config/aws/VaultConfigAwsBootstrapConfigurationTests.java
+++ b/spring-cloud-vault-config-aws/src/test/java/org/springframework/cloud/vault/config/aws/VaultConfigAwsBootstrapConfigurationTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.vault.config.aws;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
linting issue preventing builds from passing:

```shell
[INFO] Reactor Summary for Spring Cloud Vault 5.0.1-SNAPSHOT:
[INFO] 
[INFO] Spring Cloud Vault Dependencies .................... SUCCESS [  0.033 s]
[INFO] Spring Cloud Vault ................................. SUCCESS [  0.848 s]
[INFO] Spring Cloud Vault Configuration Integration ....... SUCCESS [  8.537 s]
[INFO] Spring Cloud Vault Config Database support ......... SUCCESS [  2.175 s]
[INFO] Spring Cloud Vault Config Consul support ........... SUCCESS [  1.771 s]
[INFO] Spring Cloud Vault Config RabbitMQ support ......... SUCCESS [  1.766 s]
[INFO] Spring Cloud Vault Config AWS support .............. FAILURE [  0.267 s]
[INFO] Spring Cloud Starter Vault Config .................. SKIPPED
[INFO] Spring Cloud Vault Docs ............................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  15.488 s
[INFO] Finished at: 2025-12-19T12:24:19-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.6.0:check (checkstyle-validation) on project spring-cloud-vault-config-aws: Failed during checkstyle execution: There are 2 errors reported by Checkstyle 12.1.2 with checkstyle.xml ruleset. -> [Help 1]```

fixed by removing unused imports