### PR TITLE
GH-920 Handle duplicate database roles

### DIFF
--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseBootstrapConfiguration.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseBootstrapConfiguration.java
@@ -85,7 +85,8 @@ public class VaultConfigDatabaseBootstrapConfiguration {
 
 				@Override
 				public String getName() {
-					return String.format("%s with Role %s", properties.getBackend(), properties.getRole());
+					return String.format("%s with Role %s using %s/%s", properties.getBackend(), properties.getRole(),
+							properties.getUsernameProperty(), properties.getPasswordProperty());
 				}
 
 				@Override

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseBootstrapConfigurationUnitTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseBootstrapConfigurationUnitTests.java
@@ -16,9 +16,13 @@
 
 package org.springframework.cloud.vault.config.databases;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.vault.config.SecretBackendMetadata;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.MapPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,6 +46,43 @@ public class VaultConfigDatabaseBootstrapConfigurationUnitTests {
 		SecretBackendMetadata metadata = factory.createMetadata(properties);
 
 		assertThat(metadata.getPath()).isEqualTo("database/static-creds/my-role");
+	}
+
+	@Test
+	public void shouldContributePropertiesForSameRoleWithDifferentTargetProperties() {
+
+		VaultConfigDatabaseBootstrapConfiguration.DatabaseSecretBackendMetadataFactory factory = new VaultConfigDatabaseBootstrapConfiguration()
+			.databaseSecretBackendMetadataFactory();
+
+		VaultDatabaseProperties primary = databaseProperties("db1-dbuser", "spring.datasource.username",
+				"spring.datasource.password");
+		VaultDatabaseProperties secondary = databaseProperties("db1-dbuser", "spring.secondary-datasource.username",
+				"spring.secondary-datasource.password");
+
+		SecretBackendMetadata primaryMetadata = factory.createMetadata(primary);
+		SecretBackendMetadata secondaryMetadata = factory.createMetadata(secondary);
+		Map<String, Object> secret = Map.of("username", "vault-user", "password", "vault-password");
+
+		CompositePropertySource propertySource = new CompositePropertySource("vault");
+		propertySource.addPropertySource(new MapPropertySource(primaryMetadata.getName(),
+				primaryMetadata.getPropertyTransformer().transformProperties(secret)));
+		propertySource.addPropertySource(new MapPropertySource(secondaryMetadata.getName(),
+				secondaryMetadata.getPropertyTransformer().transformProperties(secret)));
+
+		assertThat(propertySource.getProperty("spring.datasource.username")).isEqualTo("vault-user");
+		assertThat(propertySource.getProperty("spring.datasource.password")).isEqualTo("vault-password");
+		assertThat(propertySource.getProperty("spring.secondary-datasource.username")).isEqualTo("vault-user");
+		assertThat(propertySource.getProperty("spring.secondary-datasource.password")).isEqualTo("vault-password");
+	}
+
+	private static VaultDatabaseProperties databaseProperties(String role, String usernameProperty,
+			String passwordProperty) {
+
+		VaultDatabaseProperties properties = new VaultDatabaseProperties();
+		properties.setRole(role);
+		properties.setUsernameProperty(usernameProperty);
+		properties.setPasswordProperty(passwordProperty);
+		return properties;
 	}
 
 }


### PR DESCRIPTION
## Summary

- Use distinct database secret backend metadata names when the same Vault database role maps to different target username and password properties.
- Allow multiple `spring.cloud.vault.databases` entries with the same backend and role to contribute separate datasource credential properties.
- Add regression coverage for primary and secondary datasource properties backed by the same Vault database role.

Fixes gh-920

## Testing

- `git diff --check`
- `./mvnw -pl spring-cloud-vault-config-databases -Dtest='*UnitTests' test`