### PR TITLE
Ignore release train workflow files in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "main"
+    exclude-paths:
+      - ".github/workflows/release-train-test.yml"
+      - ".github/workflows/release-train-build.yml"
     schedule:
       interval: "weekly"
   - package-ecosystem: maven


### PR DESCRIPTION
Dependabot is opening GitHub Actions updates for release train workflow files that are generated and not intended for direct dependency maintenance. This change prevents noisy update churn for those generated workflows.

## What changed
- Added `exclude-paths` to the `github-actions` update entry in `.github/dependabot.yml`
- Excluded:
  - `.github/workflows/release-train-test.yml`
  - `.github/workflows/release-train-build.yml`

## Notes
This only affects the GitHub Actions ecosystem entry and leaves other Dependabot update configuration unchanged.